### PR TITLE
product: fix delivery_time parsing

### DIFF
--- a/lib/zanox/resources/product.rb
+++ b/lib/zanox/resources/product.rb
@@ -100,6 +100,7 @@ module Zanox
     end
 
     def only_numbers(s)
+      return s if s.is_a?(Numeric)
       s ? s.scan(/\d+/).last.to_i : s
     end
   end


### PR DESCRIPTION
Sometimes deliveryTime is not returned as a String, so it throws `NoMethodError: undefined method 'scan' for Fixnum` when calling `only_numbers`.
